### PR TITLE
Change autogenerated adminPassword from 3 to 2 words

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -16,7 +16,7 @@ def random_passphrase():
     while "'" in password:
         with open("/usr/share/dict/american-english") as f:
             words = f.readlines()
-        password = "-".join(random.sample(words, 3)).replace("\n", "").lower()
+        password = "-".join(random.sample(words, 2)).replace("\n", "").lower()
     return password
 
 


### PR DESCRIPTION
When merged, this PR will:
- title

Sometimes the words used to generate password are too long and the password will exceed the limit:
```
# 2023-11-22T00:06:12.302710500Z    BACKEND   (E): Param "#/game/passwordAdmin" has surpassed the maximum limit of value/length. The maximum allowed is 32.`
```

I think reducing the # of words is better than cutting after 32 character.

Or we could just regenerate if the pass exceeds 32 chars 🤔 