### PR TITLE
require RCON password to enable

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -69,7 +69,11 @@ else:
     else:
         config["a2s"] = None
 
-    if env_defined("RCON_ADDRESS") and env_defined("RCON_PORT") and env_defined("RCON_PASSWORD"):
+    if (
+        env_defined("RCON_ADDRESS")
+        and env_defined("RCON_PORT")
+        and env_defined("RCON_PASSWORD")
+    ):
         config["rcon"] = {
             "address": os.environ["RCON_ADDRESS"],
             "port": int(os.environ["RCON_PORT"]),

--- a/launch.py
+++ b/launch.py
@@ -69,7 +69,7 @@ else:
     else:
         config["a2s"] = None
 
-    if env_defined("RCON_ADDRESS") and env_defined("RCON_PORT"):
+    if env_defined("RCON_ADDRESS") and env_defined("RCON_PORT") and env_defined("RCON_PASSWORD"):
         config["rcon"] = {
             "address": os.environ["RCON_ADDRESS"],
             "port": int(os.environ["RCON_PORT"]),


### PR DESCRIPTION
Server won't launch with current defaults
```
BACKEND      : Loading dedicated server config.
 BACKEND      : JSON Schema Validation:
  BACKEND      : minLength error:
   BACKEND   (E): Param "#/rcon/password" is bellow the minimum limit of value/length. The minimum allowed is 3.
   BACKEND   (E): RegEx Pattern: "^[^ ]*$"
   BACKEND   (E): Pattern Description: "Spaces are not allowed."
   BACKEND   (E): Reference in schema: "#/properties/rcon/properties/password"
  BACKEND   (E): JSON is invalid!
 BACKEND   (E): There are errors in server config!
BACKEND   (E): Unable to continue with a broken DS config! Shutdown!
```