### PR TITLE
Launch with subprocess

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -202,7 +202,7 @@ launch = [
     *shlex.split(os.environ["ARMA_PARAMS"]),
 ]
 
-print(" ".join(launch), flush=True)
+print(shlex.join(launch), flush=True)
 
 proc = subprocess.Popen(launch)
 

--- a/launch.py
+++ b/launch.py
@@ -4,6 +4,7 @@ import random
 import re
 import shlex
 import subprocess
+import sys
 
 CONFIG_GENERATED = "/reforger/Configs/docker_generated.json"
 
@@ -203,10 +204,10 @@ proc = subprocess.Popen(launch)
 
 try:
     try:
-        proc.wait()
+        sys.exit(proc.wait())
     except KeyboardInterrupt:
         proc.terminate()
-        proc.wait()
+        sys.exit(proc.wait())
 except BaseException:
     proc.kill()
     raise

--- a/launch.py
+++ b/launch.py
@@ -3,8 +3,12 @@ import os
 import random
 import re
 import shlex
+import signal
 import subprocess
 import sys
+
+# On SIGTERM, raise KeyboardInterrupt instead of exiting abruptly.
+signal.signal(signal.SIGTERM, signal.default_int_handler)
 
 CONFIG_GENERATED = "/reforger/Configs/docker_generated.json"
 

--- a/launch.py
+++ b/launch.py
@@ -202,7 +202,11 @@ print(" ".join(launch), flush=True)
 proc = subprocess.Popen(launch)
 
 try:
-    proc.wait()
-except KeyboardInterrupt:
-    proc.terminate()
-    proc.wait()
+    try:
+        proc.wait()
+    except KeyboardInterrupt:
+        proc.terminate()
+        proc.wait()
+except BaseException:
+    proc.kill()
+    raise

--- a/launch.py
+++ b/launch.py
@@ -210,7 +210,7 @@ try:
     try:
         sys.exit(proc.wait())
     except KeyboardInterrupt:
-        proc.terminate()
+        proc.send_signal(signal.SIGINT)
         sys.exit(proc.wait())
 except BaseException:
     proc.kill()

--- a/launch.py
+++ b/launch.py
@@ -2,6 +2,7 @@ import json
 import os
 import random
 import re
+import shlex
 import subprocess
 
 CONFIG_GENERATED = "/reforger/Configs/docker_generated.json"
@@ -179,18 +180,22 @@ else:
 
     config_path = CONFIG_GENERATED
 
-launch = " ".join(
-    [
-        os.environ["ARMA_BINARY"],
-        f"-config {config_path}",
-        "-backendlog",
-        "-nothrow",
-        f"-maxFPS {os.environ['ARMA_MAX_FPS']}",
-        f"-profile {os.environ['ARMA_PROFILE']}",
-        f"-addonDownloadDir {os.environ['ARMA_WORKSHOP_DIR']}",
-        f"-addonsDir {os.environ['ARMA_WORKSHOP_DIR']}",
-        os.environ["ARMA_PARAMS"],
-    ]
-)
-print(launch, flush=True)
-os.system(launch)
+launch = [
+    os.environ["ARMA_BINARY"],
+    "-config",
+    config_path,
+    "-backendlog",
+    "-nothrow",
+    "-maxFPS",
+    os.environ["ARMA_MAX_FPS"],
+    "-profile",
+    os.environ["ARMA_PROFILE"],
+    "-addonDownloadDir",
+    os.environ["ARMA_WORKSHOP_DIR"],
+    "-addonsDir",
+    os.environ["ARMA_WORKSHOP_DIR"],
+    *shlex.split(os.environ["ARMA_PARAMS"]),
+]
+
+print(" ".join(launch), flush=True)
+subprocess.call(launch)

--- a/launch.py
+++ b/launch.py
@@ -198,4 +198,11 @@ launch = [
 ]
 
 print(" ".join(launch), flush=True)
-subprocess.call(launch)
+
+proc = subprocess.Popen(launch)
+
+try:
+    proc.wait()
+except KeyboardInterrupt:
+    proc.terminate()
+    proc.wait()


### PR DESCRIPTION
This fixes the server not gracefully shutting down due to SIGINT being ignored by `os.system()`, and improves handling of signals.

The script will gracefully shutdown with with both SIGINT and SIGTERM. This PR does not modify the Dockerfile, so SIGINT remains the default stop signal.

When a SIGINT or SIGTERM is first received, the script will send SIGINT to the Reforger process and wait for it to exit. The subprocess will be killed if a second interrupt is sent, although in practice this won't matter since SIGKILL is sent when Docker times out.

As a side effect of passing an argument list to `subprocess.Popen`, command injection is no longer possible through the environment variables `ARMA_BINARY`, `ARMA_MAX_FPS`, `ARMA_PROFILE`, or `ARMA_WORKSHOP_DIR`. The `ARMA_PARAMS` variable can still be used to pass custom arguments.

`shlex.join()` is now used when printing the server command, which may result in slightly different outputs.

## Context

I had set up a server using this project's image and was planning to cron jobs to run `docker compose restart`. However, when I tested the command, the logs would not show any indication of it shutting down and it would consistently exceed the default timeout of 10 seconds. I increased this to 120s with the same results.

Bacon informed me that the script may not be passing down SIGINT to Reforger, so I looked in `launch.py` for clues and found `os.system()`. It's documentation didn't mention anything about SIGINT, but I coincidentally came across this in the subprocess docs:

> https://docs.python.org/3.9/library/subprocess.html#replacing-os-system
> The `os.system()` function ignores SIGINT and SIGQUIT signals while the command is running ...

I looked at the Dockerfile and saw it used `STOPSIGNAL SIGINT`, which is how I realized what was causing the issue. I later verified this behaviour with [these test scripts](https://gist.github.com/thegamecracks/a6cac59843acf952cdb4a74ac1f4c5e8), albeit on Python 3.12 and not 3.9 as used by Debian Bullseye.

I've updated my server to use the following image:

```sh
docker pull ghcr.io/thegamecracks/arma-reforger@sha256:f87928478a0660d72f1b580a33fb711456dc968b0725431571ea69125f3952e4
```

From preliminary testing it looks like `docker compose restart` gracefully shuts down the server correctly, although it's close to the 10s default timeout.

P.S. I could not get ghcr.yaml's test job to work on my fork as it kept hanging on `steam-query.py` without any output.