### PR TITLE
Minor adjustments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.8'
 services:
   arma-reforger:
     image: ghcr.io/acemod/arma-reforger:latest

--- a/docker_default.json
+++ b/docker_default.json
@@ -23,7 +23,8 @@
 		"visible": true,
 		"supportedPlatforms": [
 			"PLATFORM_PC",
-			"PLATFORM_XBL"
+			"PLATFORM_XBL",
+			"PLATFORM_PSN"
 		],
 		"gameProperties": {
 			"serverMaxViewDistance": 2500,

--- a/docker_default.json
+++ b/docker_default.json
@@ -19,7 +19,7 @@
 		"passwordAdmin": "",
 		"admins": [],
 		"scenarioId": "{ECC61978EDCC2B5A}Missions/23_Campaign.conf",
-		"maxPlayers": 32,
+		"maxPlayers": 64,
 		"visible": true,
 		"supportedPlatforms": [
 			"PLATFORM_PC",
@@ -27,17 +27,13 @@
 			"PLATFORM_PSN"
 		],
 		"gameProperties": {
-			"serverMaxViewDistance": 2500,
-			"serverMinGrassDistance": 50,
-			"networkViewDistance": 1000,
-			"disableThirdPerson": true,
+			"serverMaxViewDistance": 1600,
+			"serverMinGrassDistance": 0,
+			"networkViewDistance": 1500,
+			"disableThirdPerson": false,
 			"fastValidation": true,
 			"battlEye": true,
-			"missionHeader": {
-				"m_iPlayerCount": 40,
-				"m_eEditableGameFlags": 6,
-				"m_eDefaultGameFlags": 6
-			}
+			"missionHeader": {}
 		},
 		"mods": []
 	}


### PR DESCRIPTION
This PR includes a few small adjustments to improve the experience when setting up a new server:

- (b168292bb186e0f92775912f0de7a7f4afa2f7d1) Fix server startup issue
  - In the current defaults, the server does not start for vanilla games unless all platforms are enabled or only PC is selected.
  - This commit ensures that the default settings allow the server to start correctly.
- (80d74da9f4c07e6454b92189823563ab4b3bec55) Remove obsolete version attribute from docker-compose.yml
  - The version attribute is no longer required in docker-compose.yml, as Docker Compose now determines compatibility automatically.
  - Removing it avoids unnecessary warnings.
- (0786ceeeace0b536ad0df7c4bfc0a0134fa23503) Update default properties and clean up mission headers
  - Adjusted some configuration properties to match the default values from the BI wiki.
  - Removed redundant mission headers, as they are not needed.