### PR TITLE
Update GitHub Actions dependencies and add RCON password to test

### DIFF
--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -47,6 +47,7 @@ jobs:
           docker run -d
           -e SERVER_A2S_ADDRESS=0.0.0.0
           -e SERVER_A2S_PORT=17777
+          -e RCON_PASSWORD=PipelineTest123
           -p 17777:17777/udp
           arma-reforger
       - name: Install python dependencies

--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v3 
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -23,7 +23,7 @@ jobs:
         run: docker build . -t arma-reforger
       - name: Save Image
         run: docker save arma-reforger | gzip > image.tar.gz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: image
           path: image.tar.gz
@@ -37,7 +37,7 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@master
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v5
         with:
           name: image
       - name: Load Image
@@ -63,12 +63,12 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v5
         with:
           name: image
       - name: Load Image


### PR DESCRIPTION
## What Changed

This PR updates the GitHub Actions workflow dependencies to their latest versions and adds RCON password configuration for functional testing.

- `docker/login-action`: v1 → v3
- `actions/upload-artifact`: v2 → v4  
- `actions/download-artifact`: v2 → v5
- Added `RCON_PASSWORD=PipelineTest123` environment variable to the test container for RCON authentication

## Why

The workflow would fail for two reasons:

1. Deprecated actions
2. RCON_PASSWORD not being set thus the server failed to start and the build did not pass the test (#39 should solve this)